### PR TITLE
`keyWithPrefix()` method optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,9 @@ All notable changes to `redis-helpers` will be documented in this file
 
 ## 1.3.0 - 2021-03-31
 - cut sfneal/actions composer requirement
+
+
+## 1.3.1 - 2021-04-28
+- cut sfneal/actions composer requirement
+- add conditional to `keyWithPrefix()` to prevent adding a prefix when none is set
+- optimize type hinting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,7 @@ All notable changes to `redis-helpers` will be documented in this file
 ## 1.2.2 - 2021-03-30
 - fix sfneal/actions version syntax
 - fix Travis CI config to enable code coverage uploads
+
+
+## 1.3.0 - 2021-03-31
+- cut sfneal/actions composer requirement

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "laravel/framework": ">=5.6.0",
-        "sfneal/actions": "^1.0"
+        "laravel/framework": ">=5.6.0"
     },
     "require-dev": {
         "josiasmontag/laravel-redis-mock": ">=1.2.6",

--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -26,7 +26,10 @@ class RedisCache
      */
     private static function keyWithPrefix(string $key): string
     {
-        return config('cache.prefix').":{$key}";
+        if (! is_null(config('cache.prefix'))) {
+            return config('cache.prefix').":{$key}";
+        }
+        return $key;
     }
 
     /**

--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -5,9 +5,8 @@ namespace Sfneal\Helpers\Redis;
 use Closure;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
-use Sfneal\Actions\AbstractService;
 
-class RedisCache extends AbstractService
+class RedisCache
 {
     /**
      * Retrieve the Redis Key TTL from the config.

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -18,6 +18,6 @@ class LaravelConfigTest extends TestCase
         $output = config('redis-helpers.ttl');
         $expected = 3600;
         $this->assertIsInt($output);
-        $this->assertTrue($output == $expected);
+        $this->assertSame($expected, $output);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,9 +28,9 @@ class TestCase extends OrchestraTestCase
      * Register package service providers.
      *
      * @param Application $app
-     * @return array|string
+     * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             RedisHelpersServiceProvider::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Application;
 use Lunaweb\RedisMock\Providers\RedisMockServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Sfneal\Helpers\Redis\Providers\RedisHelpersServiceProvider;
-use Sfneal\Helpers\Redis\RedisCache;
 
 class TestCase extends OrchestraTestCase
 {
@@ -36,16 +35,5 @@ class TestCase extends OrchestraTestCase
             RedisHelpersServiceProvider::class,
             RedisMockServiceProvider::class,
         ];
-    }
-
-    /**
-     * Clean up the testing environment before the next test.
-     *
-     * @return void
-     */
-    protected function tearDown(): void
-    {
-        RedisCache::flush();
-        parent::tearDown();
     }
 }


### PR DESCRIPTION
- cut sfneal/actions composer requirement
- add conditional to `keyWithPrefix()` to prevent adding a prefix when none is set
- optimize type hinting