### PR TITLE
Fix issues with deleting nested keys

### DIFF
--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -3,6 +3,7 @@
 namespace Sfneal\Helpers\Redis;
 
 use Closure;
+use ErrorException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Redis;
 
@@ -53,17 +54,23 @@ class RedisCache
      */
     public static function keys(string $prefix = '', bool $wildcard = true)
     {
-        return array_map(
+        try {
+            return array_map(
             // Remove prefix from each key so that it's not concatenated twice
-            function ($key) {
-                return substr($key, strlen(config('cache.prefix')) + 1);
-            },
+                function ($key) {
+                    return substr($key, strlen(config('cache.prefix')) + 1);
+                },
 
-            // List of Redis key's matching pattern
-            Redis::connection()
-                ->client()
-                ->keys(self::keyWithPrefix($prefix.($wildcard ? '*' : '')))
-        );
+                // List of Redis key's matching pattern
+                Redis::connection()
+                    ->client()
+                    ->keys(self::keyWithPrefix($prefix.($wildcard ? '*' : '')))
+            );
+        }
+
+        catch (ErrorException $e) {
+            return [$prefix];
+        }
     }
 
     /**

--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -66,9 +66,7 @@ class RedisCache
                     ->client()
                     ->keys(self::keyWithPrefix($prefix.($wildcard ? '*' : '')))
             );
-        }
-
-        catch (ErrorException $e) {
+        } catch (ErrorException $e) {
             return [$prefix];
         }
     }

--- a/tests/Unit/Traits/NestedKeysTest.php
+++ b/tests/Unit/Traits/NestedKeysTest.php
@@ -63,19 +63,19 @@ trait NestedKeysTest
     public function nested_delete_key()
     {
         $array = [
-            'bos:63:pos' => 'w',
-            'bos:63:name_first' => 'Brad',
-            'bos:63:name_last' => 'Marchand',
-            'bos:63:age' => 32,
+            'bos:63#pos' => 'w',
+            'bos:63#name_first' => 'Brad',
+            'bos:63#name_last' => 'Marchand',
+            'bos:63#age' => 32,
         ];
         RedisCache::setMany($array);
 
-        $key = 'bos:63:pos';
+        $key = 'bos:63#pos';
         $this->assertTrue(RedisCache::exists($key));
         RedisCache::delete($key);
 
         $this->assertFalse(RedisCache::exists($key));
-        $this->assertTrue(RedisCache::exists('bos:63:name_first'));
+        $this->assertTrue(RedisCache::exists('bos:63#name_first'));
         $this->assertTrue(RedisCache::missing($key));
     }
 

--- a/tests/Unit/Traits/NestedKeysTest.php
+++ b/tests/Unit/Traits/NestedKeysTest.php
@@ -74,7 +74,7 @@ trait NestedKeysTest
         $this->assertTrue(RedisCache::exists($key));
         $deleted = RedisCache::delete($key);
 
-        $this->assertEquals(array_fill_keys(array_keys($array), 1), $deleted);
+        $this->assertEquals(['bos:63#pos' => true], $deleted);
 
         $this->assertFalse(RedisCache::exists($key));
         $this->assertTrue(RedisCache::exists('bos:63#name_first'));

--- a/tests/Unit/Traits/NestedKeysTest.php
+++ b/tests/Unit/Traits/NestedKeysTest.php
@@ -72,7 +72,9 @@ trait NestedKeysTest
 
         $key = 'bos:63#pos';
         $this->assertTrue(RedisCache::exists($key));
-        RedisCache::delete($key);
+        $deleted = RedisCache::delete($key);
+
+        $this->assertEquals(array_fill_keys(array_keys($array), 1), $deleted);
 
         $this->assertFalse(RedisCache::exists($key));
         $this->assertTrue(RedisCache::exists('bos:63#name_first'));
@@ -93,6 +95,7 @@ trait NestedKeysTest
         $key = 'bos:46';
         $deleted = RedisCache::delete($key);
 
+        $this->assertEquals(array_fill_keys(array_keys($array), 1), $deleted);
         $this->assertFalse(RedisCache::exists($key));
 
         foreach (array_keys($array) as $key) {


### PR DESCRIPTION
- fix issues with nested keys tests failing while using the 'mock' redis client
- add try/catch block to `RedisCache::key()` method so that when an error is encountered while trying to find child keys, the original key is returned